### PR TITLE
factorize image loading, properly strip image extension, strip whitespaces…

### DIFF
--- a/import_bsp/BspGeneric.py
+++ b/import_bsp/BspGeneric.py
@@ -36,7 +36,7 @@ def pack_lightmaps(bsp, import_settings):
     color_scale = 1.0
     color_components = 4
     try:
-        path = bsp.bsp_path.replace(".bsp", "\\")
+        path = bsp.bsp_path[:-len(".bsp")] + "\\"
         lm_files = os.listdir(path)
         lm_list = [path + file_name
                     for file_name in lm_files

--- a/import_bsp/BspImport.py
+++ b/import_bsp/BspImport.py
@@ -154,7 +154,8 @@ class Operator(bpy.types.Operator, ImportHelper):
                     bpy.context.collection.objects.link(cube)
                 
                 if "model" in ent and (ent["classname"] == "misc_model_static" or ent["classname"] == "misc_model_breakable"):
-                    mesh_name = ent["model"].replace(".md3","")
+                    # FIXME: what if the model is not md3?
+                    mesh_name = ent["model"][:-len(".md3")]
                     zoffset = 0
                     if "zoffset" in ent:
                         zoffset = int(ent["zoffset"].replace('"','')) + 1

--- a/import_bsp/Image.py
+++ b/import_bsp/Image.py
@@ -1,0 +1,23 @@
+#-*- coding: UTF-8 -*-
+
+if "bpy" not in locals():
+    import bpy
+
+extensions = [ ".png", ".tga", ".jpg", ".jpeg" ]
+
+def remove_file_extension(file_path):
+    for extension in extensions:
+        if file_path.endswith(extension):
+            return file_path.replace(extension, "")
+    return file_path
+
+def load_file(base_path, file_path):
+    file_path_without_ext = remove_file_extension(file_path)
+
+    for extension in extensions:
+        try:
+            return bpy.data.images.load(base_path + "/" + file_path_without_ext + extension, check_existing=True)
+        except:
+            continue
+    print("couldn't load texture: ", file_path)
+    return None

--- a/import_bsp/Image.py
+++ b/import_bsp/Image.py
@@ -3,10 +3,13 @@
 if "bpy" not in locals():
     import bpy
 
-extensions = [ ".png", ".tga", ".jpg", ".jpeg" ]
+# move file extension from first array to second one
+# when the format is supported
+unsupported_extensions = [ ".bmp", ".webp", ".ktx", ".dds", ".crn" ]
+extensions = [ ".tga", ".png", ".jpg", ".jpeg" ]
 
 def remove_file_extension(file_path):
-    for extension in extensions:
+    for extension in extensions + unsupported_extensions:
         if file_path.lower().endswith(extension):
             return file_path[:-len(extension)]
     return file_path

--- a/import_bsp/Image.py
+++ b/import_bsp/Image.py
@@ -7,8 +7,8 @@ extensions = [ ".png", ".tga", ".jpg", ".jpeg" ]
 
 def remove_file_extension(file_path):
     for extension in extensions:
-        if file_path.endswith(extension):
-            return file_path.replace(extension, "")
+        if file_path.lower().endswith(extension):
+            return file_path[:-len(extension)]
     return file_path
 
 def load_file(base_path, file_path):

--- a/import_bsp/MD3.py
+++ b/import_bsp/MD3.py
@@ -230,8 +230,8 @@ def ImportMD3(model_name, import_settings, zoffset):
             shaderindex += 1
             face_index_offset += n_indices
             
-        if name.endswith(".md3"):
-            name = name.replace(".md3", "")
+        if name.lower().endswith(".md3"):
+            name = name[:-len(extension)]
             
         mesh = bpy.data.meshes.new( name )
         mesh.from_pydata(vertex_pos, [], face_indices)

--- a/import_bsp/MD3.py
+++ b/import_bsp/MD3.py
@@ -8,6 +8,11 @@ if "struct" not in locals():
 if "bpy" not in locals():
     import bpy
     
+if "Image" in locals():
+    imp.reload( Image )
+else:
+    from . import Image
+
 from math import pi, sin, cos, atan2, acos
 from bpy_extras.io_utils import unpack_list
     
@@ -95,15 +100,8 @@ class MD3:
             size = STRING + INT
             encoding = "<64si"
             
-            def remove_file_extention(self, file_path):
-                extensions = [".jpg", ".jpeg", ".tga", ".png"]
-                for extension in extensions:
-                    if file_path.endswith(extension):
-                        return file_path.replace(extension, "")
-                return file_path
-                    
             def __init__(self, array):
-                self.name =     self.remove_file_extention(array[0].decode("utf-8", errors="ignore").strip("\0"))
+                self.name =     Image.remove_file_extension(array[0].decode("utf-8", errors="ignore").strip("\0"))
                 self.index =    array[1]
                 
         class triangle:

--- a/import_bsp/QuakeShader.py
+++ b/import_bsp/QuakeShader.py
@@ -27,6 +27,11 @@ if "QuakeSky" in locals():
 else:
     from . import QuakeSky
     
+if "Image" in locals():
+    imp.reload( Image )
+else:
+    from . import Image
+
 from math import radians
 
 LIGHTING_IDENTITY = 0
@@ -369,7 +374,7 @@ class quake_shader:
             if (stage.diffuse == "$whiteimage" or stage.diffuse == "$lightmap"):
                 img = bpy.data.images[stage.diffuse]
             else:
-                img = shader.load_image(base_path, stage.diffuse)
+                img = Image.load_file(base_path, stage.diffuse)
             
             if img is not None:        
                 node_color = shader.nodes.new(type='ShaderNodeTexImage')
@@ -469,19 +474,6 @@ class quake_shader:
         if (stage.valid or stage.lightmap):
             shader.stages.append(stage)
             shader.is_explicit = True
-            
-    def load_image(shader, base_path, texture_path):
-        extensions = [ ".png", ".tga", ".jpg" ]
-        for extension in extensions:
-            if texture_path.endswith(extension):
-                texture_path = texture_path.replace(extension,"")
-        for extension in extensions:
-            try:
-                return bpy.data.images.load(base_path + "/" + texture_path + extension, check_existing=True)
-            except:
-                continue
-        print("couldn't load texture: ", texture_path)
-        return None
             
     def finish_shader(shader, base_path):
         
@@ -625,7 +617,7 @@ class quake_shader:
                 print(shader.name + " shader is not supported right now")
             
         else:
-            img = shader.load_image(base_path, shader.texture)
+            img = Image.load_file(base_path, shader.texture)
             if img is not None:
                 img.alpha_mode = "CHANNEL_PACKED"
                 if shader.is_vertex_lit:

--- a/import_bsp/QuakeShader.py
+++ b/import_bsp/QuakeShader.py
@@ -732,6 +732,7 @@ def parse(line):
             key, value = line.split('\t', 1)
         except:
             key, value = line.split(' ', 1)
+        value = value.strip("\t ")
     except:
         key = line
         value = 1

--- a/import_bsp/QuakeSky.py
+++ b/import_bsp/QuakeSky.py
@@ -3,21 +3,15 @@
 #TODO: refactor image loading here and in QuakeShader
 #----------------------------------------------------------------------------#
 
-import bpy
-import math
+if "bpy" not in locals():
+    import bpy
 
-def load_image(base_path, texture_path):
-    extensions = [ ".png", ".tga", ".jpg" ]
-    for extension in extensions:
-        if texture_path.endswith(extension):
-            texture_path = texture_path.replace(extension,"")
-    for extension in extensions:
-        try:
-            return bpy.data.images.load(base_path + "/" + texture_path + extension, check_existing=True)
-        except:
-            continue
-    print("couldn't load texture: ", texture_path)
-    return None
+if "Image" in locals():
+    imp.reload( Image )
+else:
+    from . import Image
+
+import math
 
 def make_equirectangular_from_sky(base_path, sky_name):
     textures = [sky_name + "_up", 
@@ -33,7 +27,7 @@ def make_equirectangular_from_sky(base_path, sky_name):
     biggest_w = 512
                  
     for index,tex in enumerate(textures):
-        image = load_image(base_path, tex)
+        image = Image.load_file(base_path, tex)
         
         if image == None:
             cube[index] = []


### PR DESCRIPTION
factorize image loading

properly strip image extension (what if image is named `something.jpg.something.tga`?)

add a quick and dirty hack for lines like that:

```
    map    something.jpg
```

to not have the image path being (with leading spaces): `"   something.jpg"`

this one would benefit from a better shader parser design instead.