### PR TITLE
option to guess base path: use parent of map directory as base path

### DIFF
--- a/import_bsp/BspImport.py
+++ b/import_bsp/BspImport.py
@@ -95,14 +95,12 @@ class Operator(bpy.types.Operator, ImportHelper):
         if prefs.guess_base_path:
             dataPath = self.properties.filepath
             fixed_base_path = path.dirname(path.dirname(dataPath))
+            context.scene.guessed_base_path = fixed_base_path
         else:
             fixed_base_path = prefs.base_path
 
         if not fixed_base_path.endswith('/'):
             fixed_base_path = fixed_base_path + '/'
-
-        # HACK: hack prefs as global for Reload_shader
-        context.preferences.addons[addon_name].preferences.guessed_base_path = fixed_base_path
 
         #trace some things like paths and lightmap size
         import_settings = ImportSettings()
@@ -392,9 +390,9 @@ class Reload_shader(bpy.types.Operator):
         addon_name = __name__.split('.')[0]
         prefs = context.preferences.addons[addon_name].preferences
 
-        # HACK: hack prefs as global for Reload_shader
-        if prefs.guess_base_path:
-            fixed_base_path = prefs.guessed_base_path
+        if prefs.guess_base_path and hasattr(context.scene, "guessed_base_path"):
+            fixed_base_path = context.scene.guessed_base_path
+            print("2: " + context.scene.guessed_base_path)
         else:
             fixed_base_path = prefs.base_path
 

--- a/import_bsp/__init__.py
+++ b/import_bsp/__init__.py
@@ -48,6 +48,17 @@ class BspImportAddonPreferences(bpy.types.AddonPreferences):
 
     bl_idname = __name__
 
+    guess_base_path : bpy.props.BoolProperty(
+        name="Guess base path from map path",
+        description="Use parent of map directory as base path",
+        default=False
+        )
+
+    # HACK: hack prefs as global for Reload_shader
+    guessed_base_path : bpy.props.StringProperty(
+        maxlen=2048,
+        )
+
     base_path : bpy.props.StringProperty(
         name="basepath",
         description="Path to base folder",
@@ -65,9 +76,11 @@ class BspImportAddonPreferences(bpy.types.AddonPreferences):
     def draw(self, context):
         layout = self.layout
         row = layout.row()
+        row.prop(self, "guess_base_path")
+        row = layout.row()
         row.prop(self, "base_path")
         #layout.prop(self, "shader_dir")
-	
+
 classes = ( BspImport.Operator,
             BspImportAddonPreferences,
             BspImport.Q3_PT_MappingPanel,

--- a/import_bsp/__init__.py
+++ b/import_bsp/__init__.py
@@ -19,11 +19,11 @@
 bl_info = {
     "name": "Import id Tech 3 BSP",
     "author": "SomaZ",
-	"version": (0, 9, 0),
+    "version": (0, 9, 0),
     "description": "Importer for id Tech 3 BSP levels",
     "blender": (2, 81, 16),
     "location": "File > Import-Export",
-	"warning": "",
+    "warning": "",
     "category": "Import-Export"
 }
 
@@ -52,11 +52,6 @@ class BspImportAddonPreferences(bpy.types.AddonPreferences):
         name="Guess base path from map path",
         description="Use parent of map directory as base path",
         default=False
-        )
-
-    # HACK: hack prefs as global for Reload_shader
-    guessed_base_path : bpy.props.StringProperty(
-        maxlen=2048,
         )
 
     base_path : bpy.props.StringProperty(
@@ -91,8 +86,16 @@ def register():
         bpy.utils.register_class(cls)
     bpy.types.TOPBAR_MT_file_import.append(BspImport.menu_func)
 
+    # note: this is stored in .blend file
+    bpy.types.Scene.guessed_base_path = bpy.props.StringProperty(
+        name="Guessed base path",
+        description="Base path guessed from map path",
+        default="",
+        )
+
 def unregister():
     bpy.types.TOPBAR_MT_file_import.remove(BspImport.menu_func)
+    bpy.types.Scene.remove(guessed_base_path)
     for cls in classes:
         bpy.utils.unregister_class(cls)
 


### PR DESCRIPTION
I made this option to make easy to test multiple games. Basically I extracted all pk3 from each game I have as one unpacked directory per game. So, opening `some/path/to/maps/castle.map` will use `some/path/to` as base path/

Note: I don't know how to disable the basepath option when this one is enabled.